### PR TITLE
Fix horizontal scrolling not working when pages overflow viewport

### DIFF
--- a/src/book-view.vala
+++ b/src/book-view.vala
@@ -252,7 +252,7 @@ public class BookView : Gtk.Box
         if (page == null)
             return;
 
-        int allocation_width = drawing_area.get_allocated_width();
+        int allocation_width = scrolled_window.get_allocated_width();
         var left_edge = page.x_offset;
         var right_edge = page.x_offset + page.width;
 
@@ -411,8 +411,15 @@ public class BookView : Gtk.Box
 
         laying_out = true;
 
-        int width = drawing_area.get_allocated_width();
+        int width = scrolled_window.get_allocated_width();
         int height = this.get_allocated_height();
+
+        /* Don't layout before widgets are allocated */
+        if (width <= 0 || height <= 0)
+        {
+            laying_out = false;
+            return;
+        }
 
         int book_width, book_height;
         layout_into (width, height, out book_width, out book_height);


### PR DESCRIPTION
show_page_view() used drawing_area.get_allocated_width() to determine if a page was off-screen, but inside a ScrolledWindow the DrawingArea is allocated the full content width (all pages), not the viewport width. This meant the "scroll right to reveal page" condition never triggered.

Fixed by using scrolled_window.get_allocated_width() which returns the actual visible viewport width. Also applied the same fix to layout() and added a guard against zero-size allocations during early init.